### PR TITLE
Needs GHC >= 7.8 due to Data.Bool.bool

### DIFF
--- a/notzero.cabal
+++ b/notzero.cabal
@@ -29,7 +29,7 @@ library
                     Haskell2010
 
   build-depends:
-                      base          >= 3   && < 5
+                      base          >= 4.7 && < 5
                     , mtl           >= 2.0 && < 2.3
                     , semigroups    >= 0.8
                     , semigroupoids >= 4.0
@@ -62,7 +62,7 @@ test-suite doctests
                     Haskell2010
 
   build-depends:
-                      base < 5 && >= 3
+                      base < 5 && >= 4.7
                     , doctest >= 0.9.7
                     , filepath >= 1.3
                     , directory >= 1.1


### PR DESCRIPTION
I've revised existing versions (http://hackage.haskell.org/package/notzero/revisions/) so a new release is only needed if you want to add backwards compatibility.
